### PR TITLE
Add footnote support to Markdoc content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,3 +42,55 @@ h1, h2, h3, h4, h5, h6,
 ::view-transition-group(nav-active-pill) {
   z-index: -1;
 }
+
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+.prose .footnote-ref {
+  font-size: 0.7em;
+  font-weight: 600;
+  vertical-align: super;
+  line-height: 0;
+  text-decoration: none;
+  padding: 0 0.15em;
+  scroll-margin-top: 6rem;
+}
+
+.prose .footnote-ref:target,
+.prose .footnotes li:target {
+  background-color: color-mix(in srgb, var(--foreground) 12%, transparent);
+  border-radius: 0.2em;
+}
+
+.prose .footnotes {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--surface-border);
+  font-size: 0.875em;
+  color: color-mix(in srgb, var(--foreground) 70%, transparent);
+}
+
+.prose .footnotes ol {
+  padding-left: 1.25em;
+}
+
+.prose .footnotes li {
+  scroll-margin-top: 6rem;
+}
+
+.prose .footnotes li p {
+  display: inline;
+  margin: 0;
+}
+
+.prose .footnote-backref {
+  margin-left: 0.35em;
+  text-decoration: none;
+}

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -3,6 +3,7 @@ import Markdoc, { nodes, Tag, type Node, type Config } from "@markdoc/markdoc";
 import React from "react";
 import type { Metadata } from "next";
 import keystaticConfig from "@/keystatic.config";
+import { applyFootnotes } from "@/lib/footnotes";
 
 const markdocConfig = {
   nodes: {
@@ -38,7 +39,10 @@ export default async function NotesIndex() {
       const { node } = await note.entry.content();
       const errors = Markdoc.validate(node);
       if (errors.length) throw new Error(`Invalid content in note ${note.slug}`);
-      const renderable = Markdoc.transform(node, markdocConfig);
+      const renderable = applyFootnotes(
+        Markdoc.transform(node, markdocConfig),
+        `${note.slug}-`,
+      );
       return { slug: note.slug, entry: note.entry, renderable };
     }),
   );

--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Markdoc, { nodes, Tag, type Node, type Config } from "@markdoc/markdoc";
 import React from "react";
 import type { Metadata } from "next";
 import keystaticConfig from "@/keystatic.config";
+import { applyFootnotes } from "@/lib/footnotes";
 
 const markdocConfig = {
   nodes: {
@@ -60,7 +61,7 @@ export default async function PostPage({
   const errors = Markdoc.validate(node);
   if (errors.length) throw new Error("Invalid content");
 
-  const renderable = Markdoc.transform(node, markdocConfig);
+  const renderable = applyFootnotes(Markdoc.transform(node, markdocConfig));
 
   const formattedDate = new Date(post.date).toLocaleDateString("en-US", {
     year: "numeric",

--- a/lib/footnotes.ts
+++ b/lib/footnotes.ts
@@ -34,7 +34,15 @@ export function applyFootnotes(
     if (!numbering.has(def.id)) numbering.set(def.id, numbering.size + 1);
   }
 
-  const orderedDefs = [...defs].sort(
+  // A footnote's own text can reference another footnote; linkify those too.
+  const linkedDefs = defs.map((def) => ({
+    id: def.id,
+    children: def.children.flatMap((child) =>
+      linkifyRefs(child, defsById, numbering, refCounts, idPrefix),
+    ),
+  }));
+
+  const orderedDefs = linkedDefs.sort(
     (a, b) => numbering.get(a.id)! - numbering.get(b.id)!,
   );
 
@@ -87,6 +95,9 @@ function linkifyRefs(
     return splitRefs(node, defsById, numbering, refCounts, idPrefix);
   }
   if (!Tag.isTag(node)) return [node];
+  // Leave code spans/blocks untouched so literal "[^1]"-looking text in
+  // snippets isn't rewritten into a link.
+  if (node.name === "code" || node.name === "pre") return [node];
 
   const children: RenderableTreeNode[] = [];
   for (const child of node.children) {

--- a/lib/footnotes.ts
+++ b/lib/footnotes.ts
@@ -1,0 +1,177 @@
+import { Tag, type RenderableTreeNode } from "@markdoc/markdoc";
+
+const REF_PATTERN = /\[\^([^\]]+)\]/g;
+const DEF_PATTERN = /^\[\^([^\]]+)\]:\s*/;
+
+type FootnoteDef = { id: string; children: RenderableTreeNode[] };
+
+/**
+ * Markdoc has no native footnote syntax, so `[^1]` refs and `[^1]: text`
+ * definitions come through as plain text. This walks the rendered tree,
+ * pulls the definition paragraphs out into a footnotes section, and turns
+ * refs into links pointing at them (with a back-link the other way).
+ */
+export function applyFootnotes(
+  tree: RenderableTreeNode,
+  idPrefix = "",
+): RenderableTreeNode {
+  if (!Tag.isTag(tree)) return tree;
+
+  const defs: FootnoteDef[] = [];
+  const withoutDefs = extractDefinitions(tree, defs);
+  if (defs.length === 0) return tree;
+
+  const defsById = new Map(defs.map((def) => [def.id, def]));
+  const numbering = new Map<string, number>();
+  const refCounts = new Map<string, number>();
+
+  const [withRefs] = linkifyRefs(withoutDefs, defsById, numbering, refCounts, idPrefix);
+  const root = withRefs as Tag;
+
+  // Any definitions never referenced in the text still get a number, appended in
+  // the order they were written.
+  for (const def of defs) {
+    if (!numbering.has(def.id)) numbering.set(def.id, numbering.size + 1);
+  }
+
+  const orderedDefs = [...defs].sort(
+    (a, b) => numbering.get(a.id)! - numbering.get(b.id)!,
+  );
+
+  root.children = [
+    ...root.children,
+    buildFootnotesSection(orderedDefs, refCounts, idPrefix),
+  ];
+  return root;
+}
+
+function extractDefinitions(node: RenderableTreeNode, defs: FootnoteDef[]): RenderableTreeNode {
+  if (!Tag.isTag(node)) return node;
+
+  const children: RenderableTreeNode[] = [];
+  for (const child of node.children) {
+    const match = matchDefinition(child);
+    if (match) {
+      defs.push(match);
+      continue;
+    }
+    children.push(extractDefinitions(child, defs));
+  }
+
+  const result = new Tag(node.name, node.attributes, children);
+  return result;
+}
+
+function matchDefinition(node: RenderableTreeNode): FootnoteDef | null {
+  if (!Tag.isTag(node) || node.name !== "p") return null;
+  const [first, ...rest] = node.children;
+  if (typeof first !== "string") return null;
+
+  const match = first.match(DEF_PATTERN);
+  if (!match) return null;
+
+  const id = match[1];
+  const remainder = first.slice(match[0].length);
+  const children = remainder ? [remainder, ...rest] : rest;
+  return { id, children };
+}
+
+function linkifyRefs(
+  node: RenderableTreeNode,
+  defsById: Map<string, FootnoteDef>,
+  numbering: Map<string, number>,
+  refCounts: Map<string, number>,
+  idPrefix: string,
+): RenderableTreeNode[] {
+  if (typeof node === "string") {
+    return splitRefs(node, defsById, numbering, refCounts, idPrefix);
+  }
+  if (!Tag.isTag(node)) return [node];
+
+  const children: RenderableTreeNode[] = [];
+  for (const child of node.children) {
+    children.push(...linkifyRefs(child, defsById, numbering, refCounts, idPrefix));
+  }
+
+  return [new Tag(node.name, node.attributes, children)];
+}
+
+function splitRefs(
+  text: string,
+  defsById: Map<string, FootnoteDef>,
+  numbering: Map<string, number>,
+  refCounts: Map<string, number>,
+  idPrefix: string,
+): RenderableTreeNode[] {
+  const parts: RenderableTreeNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(REF_PATTERN)) {
+    const id = match[1];
+    if (!defsById.has(id)) continue;
+
+    const index = match.index ?? 0;
+    if (index > lastIndex) parts.push(text.slice(lastIndex, index));
+    lastIndex = index + match[0].length;
+
+    if (!numbering.has(id)) numbering.set(id, numbering.size + 1);
+    const occurrence = (refCounts.get(id) ?? 0) + 1;
+    refCounts.set(id, occurrence);
+
+    const refId =
+      occurrence === 1 ? `fnref-${idPrefix}${id}` : `fnref-${idPrefix}${id}-${occurrence}`;
+    parts.push(
+      new Tag(
+        "a",
+        {
+          href: `#fn-${idPrefix}${id}`,
+          id: refId,
+          class: "footnote-ref",
+          role: "doc-noteref",
+          "aria-describedby": `fn-${idPrefix}${id}`,
+        },
+        [String(numbering.get(id))],
+      ),
+    );
+  }
+
+  if (lastIndex < text.length) parts.push(text.slice(lastIndex));
+  return parts.length > 0 ? parts : [text];
+}
+
+function buildFootnotesSection(
+  orderedDefs: FootnoteDef[],
+  refCounts: Map<string, number>,
+  idPrefix: string,
+): Tag {
+  const items = orderedDefs.map((def) => {
+    const backrefs: Tag[] = [];
+    const occurrences = refCounts.get(def.id) ?? 0;
+    for (let i = 1; i <= occurrences; i++) {
+      const refId =
+        i === 1 ? `fnref-${idPrefix}${def.id}` : `fnref-${idPrefix}${def.id}-${i}`;
+      backrefs.push(
+        new Tag(
+          "a",
+          {
+            href: `#${refId}`,
+            class: "footnote-backref",
+            role: "doc-backlink",
+            "aria-label": "Back to content",
+          },
+          ["↩"],
+        ),
+      );
+    }
+
+    return new Tag(
+      "li",
+      { id: `fn-${idPrefix}${def.id}` },
+      [new Tag("p", {}, [...def.children, " ", ...backrefs])],
+    );
+  });
+
+  return new Tag("section", { class: "footnotes", role: "doc-endnotes" }, [
+    new Tag("ol", {}, items),
+  ]);
+}


### PR DESCRIPTION
## Summary
Implements footnote functionality for Markdoc-rendered content, enabling authors to use standard footnote syntax (`[^1]` references and `[^1]: definition` definitions) in notes and posts.

## Changes
- **New footnotes module** (`lib/footnotes.ts`): Adds `applyFootnotes()` function that:
  - Extracts footnote definitions from rendered content
  - Converts footnote references into accessible links with proper ARIA attributes
  - Generates a footnotes section at the end of content with backlinks
  - Handles multiple references to the same footnote with unique IDs
  - Supports ID prefixing to avoid collisions across multiple documents

- **Styling** (`app/globals.css`): Added comprehensive footnote styling including:
  - Superscript styling for footnote references
  - Smooth scroll behavior with reduced-motion support
  - Highlighted target states for both references and definitions
  - Proper spacing and typography for the footnotes section
  - Accessible backlink styling

- **Integration**: Applied footnote processing to both post and notes pages:
  - `app/p/[slug]/page.tsx`: Processes individual post content
  - `app/notes/page.tsx`: Processes note content with slug-based ID prefixing

## Implementation Details
- Footnote definitions are extracted during tree traversal and removed from main content
- References are converted to anchor tags with `doc-noteref` role for accessibility
- Backlinks use `doc-backlink` role and include aria-labels
- Multiple references to the same footnote are tracked and linked appropriately
- Unreferenced definitions still appear in the footnotes section in definition order
- ID prefixing prevents conflicts when rendering multiple documents on the same page

https://claude.ai/code/session_01GRV2KLRosWnrJRQcZBfC8H