### PR TITLE
Optimize navigation modal close timing and remove unused import

### DIFF
--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -13,6 +13,15 @@ const links = [
 export function Navigation() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const [prevPathname, setPrevPathname] = useState(pathname);
+
+  // Close once the route has actually changed, instead of on click, so the
+  // modal keeps blurring the old page until the new one is ready. Adjusting
+  // state during render (rather than in an effect) avoids an extra commit.
+  if (pathname !== prevPathname) {
+    setPrevPathname(pathname);
+    setOpen(false);
+  }
 
   useEffect(() => {
     if (!open) return;
@@ -29,12 +38,6 @@ export function Navigation() {
       document.body.style.overflow = previousOverflow;
     };
   }, [open]);
-
-  // Close once the route has actually changed, instead of on click, so the
-  // modal keeps blurring the old page until the new one is ready.
-  useEffect(() => {
-    setOpen(false);
-  }, [pathname]);
 
   return (
     <nav className="relative">

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "@logtape/logtape";
-import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
 const logger = getLogger(["next-app", "middleware"]);


### PR DESCRIPTION
## Summary
Improved the navigation modal closing behavior by moving the route change detection from an effect hook to render-time state updates, and removed an unused import from the middleware.

## Key Changes
- **Navigation modal timing**: Moved the pathname change detection from a `useEffect` to synchronous state updates during render. This ensures the modal closes after the route has actually changed rather than on click, keeping the blur effect on the old page until the new one is ready. This approach avoids an extra commit cycle.
- **Removed unused import**: Deleted the unused `NextResponse` import from `proxy.ts`

## Implementation Details
The modal now uses a `prevPathname` state variable to detect when the pathname has changed. When a mismatch is detected during render, both `prevPathname` and `open` state are updated synchronously, avoiding the timing issues that occurred with the previous effect-based approach.

https://claude.ai/code/session_0129PVgYvsGc7aCDhyWkWWXi